### PR TITLE
Feat/update protobuf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ libp2p_node
 
 # logs
 *.log
+
+# test coverage
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
+
+clean:
+	rm -f coverage.txt
+	rm -f libp2p_node
+
+install:
+	go get -v -t -d ./...
+
+build:
+	go build
+
 test:
 	go test -gcflags=-l -p 1 -timeout 0 -count 1 -covermode=atomic -coverprofile=coverage.txt -v ./...
 	go tool cover -func=coverage.txt
+
 lint:
 	golines . -w
 	golangci-lint run
-	
-build:
-	go build
-install:
-	go get -v -t -d ./...
+
 race_test:
 	go test -gcflags=-l -p 1 -timeout 0 -count 1 -race -v ./...

--- a/README.md
+++ b/README.md
@@ -3,24 +3,24 @@ The `libp2p_node` is an integral part of the ACN.
 
 ## ACN - Agent Communication Network
 
-The agent communication network (ACN) provides a system for agents to find each other and communicate, solely based on their wallet addresses. It addresses the message delivery problem.
+The agent communication network (ACN) provides a system for [agents](https://github.com/valory-xyz/open-aea) 
+to find each other and communicate, solely based on their wallet addresses. 
+It addresses the message delivery problem.
 
-For more details check out the [docs](https://github.com/fetchai/agents-aea/blob/main/docs/acn.md).
+For more details check out the [docs](https://valory-xyz.github.io/open-aea/acn/).
 
 ## Development
 
 To run all tests run:
 
 ``` bash
-go test -p 1 -timeout 0 -count 1 -v ./...
+make test
 ```
 
 To lint:
 
 ``` bash
-golines . -w
-golangci-lint run
-staticcheck ./...
+make lint
 ```
 
 For mocks generation:

--- a/aea/envelope.pb.go
+++ b/aea/envelope.pb.go
@@ -7,7 +7,6 @@
 package aea
 
 import (
-	// "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/runtime/protoimpl"
 	"reflect"

--- a/aea/envelope.pb.go
+++ b/aea/envelope.pb.go
@@ -7,7 +7,7 @@
 package aea
 
 import (
-	"github.com/golang/protobuf/proto"
+	// "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/runtime/protoimpl"
 	"reflect"
@@ -23,7 +23,7 @@ const (
 
 // This is a compile-time assertion that a sufficiently up-to-date version
 // of the legacy proto package is being used.
-const _ = proto.ProtoPackageIsVersion4
+// const _ = proto.ProtoPackageIsVersion4
 
 type Envelope struct {
 	state         protoimpl.MessageState

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module libp2p_node
 
-go 1.13
+go 1.17
 
 require (
 	bou.ke/monkey v1.0.2
@@ -8,7 +8,6 @@ require (
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/ethereum/go-ethereum v1.10.10
 	github.com/golang/mock v1.5.0
-	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.3.0
 	github.com/ipfs/go-cid v0.0.5
 	github.com/joho/godotenv v1.3.0
@@ -22,9 +21,95 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/rs/zerolog v1.21.0
+	github.com/segmentio/golines v0.9.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
-	google.golang.org/protobuf v1.25.0
-	honnef.co/go/tools v0.1.4 // indirect
+	google.golang.org/protobuf v1.28.0
+)
 
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/gopacket v1.1.17 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
+	github.com/huin/goupnp v1.0.2 // indirect
+	github.com/ipfs/go-datastore v0.4.4 // indirect
+	github.com/ipfs/go-ipfs-util v0.0.1 // indirect
+	github.com/ipfs/go-ipns v0.0.2 // indirect
+	github.com/ipfs/go-log v1.0.4 // indirect
+	github.com/ipfs/go-log/v2 v2.0.5 // indirect
+	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
+	github.com/jbenet/go-temp-err-catcher v0.0.0-20150120210811-aac704a3f4f2 // indirect
+	github.com/jbenet/goprocess v0.1.4 // indirect
+	github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d // indirect
+	github.com/libp2p/go-addr-util v0.0.1 // indirect
+	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
+	github.com/libp2p/go-conn-security-multistream v0.2.0 // indirect
+	github.com/libp2p/go-eventbus v0.1.0 // indirect
+	github.com/libp2p/go-flow-metrics v0.0.3 // indirect
+	github.com/libp2p/go-libp2p-autonat v0.2.2 // indirect
+	github.com/libp2p/go-libp2p-blankhost v0.1.4 // indirect
+	github.com/libp2p/go-libp2p-discovery v0.4.0 // indirect
+	github.com/libp2p/go-libp2p-loggables v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-mplex v0.2.3 // indirect
+	github.com/libp2p/go-libp2p-nat v0.0.6 // indirect
+	github.com/libp2p/go-libp2p-peerstore v0.2.3 // indirect
+	github.com/libp2p/go-libp2p-pnet v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-record v0.1.2 // indirect
+	github.com/libp2p/go-libp2p-secio v0.2.2 // indirect
+	github.com/libp2p/go-libp2p-swarm v0.2.3 // indirect
+	github.com/libp2p/go-libp2p-tls v0.1.3 // indirect
+	github.com/libp2p/go-libp2p-transport-upgrader v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-yamux v0.2.7 // indirect
+	github.com/libp2p/go-maddr-filter v0.0.5 // indirect
+	github.com/libp2p/go-mplex v0.1.2 // indirect
+	github.com/libp2p/go-msgio v0.0.4 // indirect
+	github.com/libp2p/go-nat v0.0.5 // indirect
+	github.com/libp2p/go-netroute v0.1.2 // indirect
+	github.com/libp2p/go-openssl v0.0.4 // indirect
+	github.com/libp2p/go-reuseport v0.0.1 // indirect
+	github.com/libp2p/go-reuseport-transport v0.0.3 // indirect
+	github.com/libp2p/go-sockaddr v0.0.2 // indirect
+	github.com/libp2p/go-stream-muxer-multistream v0.3.0 // indirect
+	github.com/libp2p/go-tcp-transport v0.2.0 // indirect
+	github.com/libp2p/go-ws-transport v0.3.1 // indirect
+	github.com/libp2p/go-yamux v1.3.5 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
+	github.com/minio/sha256-simd v0.1.1 // indirect
+	github.com/mr-tron/base58 v1.1.3 // indirect
+	github.com/multiformats/go-base32 v0.0.3 // indirect
+	github.com/multiformats/go-multiaddr-dns v0.2.0 // indirect
+	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
+	github.com/multiformats/go-multiaddr-net v0.1.4 // indirect
+	github.com/multiformats/go-multibase v0.0.1 // indirect
+	github.com/multiformats/go-multistream v0.1.1 // indirect
+	github.com/multiformats/go-varint v0.0.5 // indirect
+	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.10.0 // indirect
+	github.com/prometheus/procfs v0.1.3 // indirect
+	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
+	github.com/whyrusleeping/mafmt v1.2.8 // indirect
+	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
+	go.opencensus.io v0.22.3 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
+	go.uber.org/zap v1.14.1 // indirect
+	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20220318055525-2edf467146b5 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	honnef.co/go/tools v0.1.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -193,6 +193,9 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -208,6 +211,7 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gopacket v1.1.17 h1:rMrlX2ZY2UbvT+sdz3+6J+pp2z+msCq9MxTU6ymxbBY=
@@ -661,6 +665,7 @@ github.com/rs/zerolog v1.21.0 h1:Q3vdXlfLNT+OftyBHsU0Y445MD+8m8axjKgf2si0QcM=
 github.com/rs/zerolog v1.21.0/go.mod h1:ZPhntP/xmq1nnND05hhpAh2QMhSsA4UN3MGZ6O2J3hM=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/segmentio/golines v0.9.0/go.mod h1:fVUp85HR9EzhpeAPosCkEZIKzsKA8YP83IBkhDPmYlo=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -883,6 +888,8 @@ golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 h1:uCLL3g5wH2xjxVREVuAbP9JM5PPKjRbXKRa6IBjkzmU=
 golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220318055525-2edf467146b5 h1:saXMvIOKvRFwbOMicHXr0B1uwoxq9dGmLe5ExMES6c4=
+golang.org/x/sys v0.0.0-20220318055525-2edf467146b5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -986,6 +993,10 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/protocols/acn/v1_0_0/acn.pb.go
+++ b/protocols/acn/v1_0_0/acn.pb.go
@@ -7,7 +7,7 @@
 package aea_aea_acn_v1_0_0
 
 import (
-	proto "github.com/golang/protobuf/proto"
+	//proto "google.golang.org/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -23,7 +23,7 @@ const (
 
 // This is a compile-time assertion that a sufficiently up-to-date version
 // of the legacy proto package is being used.
-const _ = proto.ProtoPackageIsVersion4
+// const _ = proto.ProtoPackageIsVersion4
 
 type AcnMessage_StatusBody_StatusCodeEnum int32
 

--- a/protocols/acn/v1_0_0/acn.pb.go
+++ b/protocols/acn/v1_0_0/acn.pb.go
@@ -7,7 +7,6 @@
 package aea_aea_acn_v1_0_0
 
 import (
-	//proto "google.golang.org/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"

--- a/protocols/acn/v1_0_0/acn.yaml
+++ b/protocols/acn/v1_0_0/acn.yaml
@@ -1,6 +1,6 @@
 ---
 name: acn
-author: fetchai
+author: valory
 version: 1.0.0
 description: The protocol used for envelope delivery on the ACN.
 license: Apache-2.0


### PR DESCRIPTION

updated protobuf module because the one we were using was deprecated 

`go: module github.com/golang/protobuf is deprecated: Use the "google.golang.org/protobuf" module instead.`
