### PR TITLE
ci: Bump Dockerfile Go to 1.24 and modernize docker job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -92,24 +92,24 @@ jobs:
       - name: Confirm Image
         run: echo "Building image for ${{env.BRANCH_NAME}}"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Declare Env Vars
         id: vars
         shell: bash
         run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: valory
           password: ${{ secrets.ACCESS_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 USER root
 
@@ -7,8 +7,8 @@ RUN apt-get update && apt-get upgrade -y
 RUN apt install -y python3 python3-pip wget
 
 # golang
-RUN wget https://dl.google.com/go/go1.17.7.linux-amd64.tar.gz && \
-  tar -xzvf go1.17.7.linux-amd64.tar.gz -C /usr/local && \
+RUN wget https://dl.google.com/go/go1.24.0.linux-amd64.tar.gz && \
+  tar -xzvf go1.24.0.linux-amd64.tar.gz -C /usr/local && \
   export PATH=$PATH:/usr/local/go/bin && echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && \
   mkdir $HOME/go
 


### PR DESCRIPTION
The docker job failed on the main-branch build after PR #18 merged because the Dockerfile still fetched go 1.17.7, which cannot parse `go 1.24.0` in go.mod (same failure mode as the golangci-lint job before its bump).

- Dockerfile: ubuntu 20.04 -> 22.04, go 1.17.7 -> 1.24.0.
- Workflow docker job: bump docker/setup-qemu-action v1 -> v3, docker/setup-buildx-action v1 -> v3, docker/login-action v1 -> v3, docker/build-push-action v2 -> v6, actions/checkout v2 -> v4, replace the deprecated `::set-output` / `##[set-output]` syntax in "Declare Env Vars" with writes to `$GITHUB_OUTPUT`.