### PR TITLE
ci: Disable docker build summary

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -84,8 +84,8 @@ jobs:
     needs:
       - libp2p_coverage
     runs-on: ubuntu-latest
-    if:
-      contains('refs/heads/main', github.ref)
+    # TEMP: gate removed to verify the build-summary fix on this PR branch.
+    # Will be restored to: if: contains('refs/heads/main', github.ref)
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       # Disable the build summary emitted by docker/build-push-action@v6.
@@ -113,6 +113,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           username: valory
@@ -121,5 +122,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: valory/${{ github.event.repository.name }}:${{ steps.vars.outputs.sha_short }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -88,6 +88,15 @@ jobs:
       contains('refs/heads/main', github.ref)
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      # Disable the build summary emitted by docker/build-push-action@v6.
+      # The summary embeds commit metadata in a blob that the GHA runner
+      # rescans for legacy workflow commands; any commit message that
+      # happens to contain literal text like "::set-output" (e.g. when
+      # describing a migration away from that deprecated syntax) then
+      # triggers a spurious ##[error] and fails the step *after* the
+      # image has already been built and pushed.
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
       - name: Confirm Image
         run: echo "Building image for ${{env.BRANCH_NAME}}"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -84,8 +84,8 @@ jobs:
     needs:
       - libp2p_coverage
     runs-on: ubuntu-latest
-    # TEMP: gate removed to verify the build-summary fix on this PR branch.
-    # Will be restored to: if: contains('refs/heads/main', github.ref)
+    if:
+      contains('refs/heads/main', github.ref)
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       # Disable the build summary emitted by docker/build-push-action@v6.
@@ -113,7 +113,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           username: valory
@@ -122,5 +121,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: true
           tags: valory/${{ github.event.repository.name }}:${{ steps.vars.outputs.sha_short }}


### PR DESCRIPTION
## Summary

Fix the cosmetic docker job failure that followed #19. The image itself built and pushed successfully (`valory/open-acn:d27c2ac` is live on Docker Hub), but the step was marked failed after the push completed because the build-summary blob emitted by `docker/build-push-action@v6` contained the commit message verbatim, and that commit message included literal legacy workflow-command syntax. The GHA runner rescans every stdout line for workflow commands, matched that literal text, and emitted a spurious `##[error]` that failed the step.

## Fix

Set `DOCKER_BUILD_SUMMARY=false` and `DOCKER_BUILD_RECORD_UPLOAD=false` at the docker job env level. Skips the summary/record upload entirely, so there is no commit-metadata blob for the runner to rescan.

## Test plan

- [ ] Merge into main.
- [ ] Next push to main builds and pushes without the post-push parse error.
