### PR TITLE
ci: Add "All checks passed" aggregate gate job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -123,3 +123,17 @@ jobs:
           context: .
           push: true
           tags: valory/${{ github.event.repository.name }}:${{ steps.vars.outputs.sha_short }}
+
+  all_checks_passed:
+    name: All checks passed
+    if: always()
+    needs:
+      - common_checks_1
+      - golang_checks
+      - libp2p_coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all dependencies succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+      - run: echo "All required checks passed."


### PR DESCRIPTION
## Summary
- Adds an `all_checks_passed` meta job that `needs` all mandatory PR jobs (`common_checks_1`, `golang_checks`, `libp2p_coverage`) and fails if any dependency failed or was cancelled.
- Excludes `docker`, which is gated to `refs/heads/main` only and so would never run on PRs.
- Intended to become the single required status check in branch protection, so adding/removing mandatory jobs only requires editing this job's `needs` list.

## Test plan
- [ ] Confirm the new `All checks passed` check appears on this PR and turns green once dependency jobs finish.
- [ ] After merge, set branch protection's required status check to `All checks passed` (strict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)