### PR TITLE
ci: publish :latest alias on main builds

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -122,7 +122,13 @@ jobs:
         with:
           context: .
           push: true
-          tags: valory/${{ github.event.repository.name }}:${{ steps.vars.outputs.sha_short }}
+          # Publish both the commit-pinned tag (for reproducible pins in
+          # downstream repos) and a ``:latest`` alias tracking main, so
+          # consumers that just want "the current image" don't have to
+          # bump a SHA on every ACN release.
+          tags: |
+            valory/${{ github.event.repository.name }}:${{ steps.vars.outputs.sha_short }}
+            valory/${{ github.event.repository.name }}:latest
 
   all_checks_passed:
     name: All checks passed


### PR DESCRIPTION
## Summary

The docker job currently only tags the pushed image with the short commit SHA:

\`\`\`yaml
tags: valory/${{ github.event.repository.name }}:${{ steps.vars.outputs.sha_short }}
\`\`\`

So Docker Hub only ever shows SHA-style tags (\`d6bf387\`, \`d2d4581\`, \`d27c2ac\`, …) and there is no \`:latest\`. That forces every downstream consumer — notably the libp2p integration tests in \`valory-xyz/open-aea\` — to pin a specific SHA and bump it on every ACN release.

Add a \`:latest\` alias pointing at whatever main is currently on, so "the current image" has a stable reference while the SHA tag is still available for reproducible pins.

## Changes

- \`.github/workflows/workflow.yml\`: append \`valory/<repo>:latest\` to the \`docker/build-push-action\` tags list on the docker job (which already runs only on \`main\`).

## Test plan

- [ ] PR CI passes (same set of jobs as before, no test changes)
- [ ] Once merged, next push to \`main\` publishes both the SHA tag and \`:latest\` to Docker Hub
- [ ] After merge + release, \`valory-xyz/open-aea#876\` can drop its \`:d6bf387\` pin and use \`:latest\`