### PR TITLE
chore(release): use DOCKER_USER/DOCKER_PASSWORD secrets in docker login

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -115,8 +115,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: valory
-          password: ${{ secrets.ACCESS_TOKEN }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary
- Replace hardcoded `username: valory` in the docker login step with `${{ secrets.DOCKER_USER }}`.
- Rename the password reference `secrets.ACCESS_TOKEN` → `secrets.DOCKER_PASSWORD` to match the canonical Docker secret names.
- No functional change at runtime: same Docker Hub account, same credential value — just stored under canonical names and resolved from secrets instead of a literal in YAML.

## Why
- A literal username in workflow YAML violates the "no literal credentials" rule and ties the workflow to a specific account name.
- `ACCESS_TOKEN` is too generic for audit (could plausibly mean a GitHub PAT, an external API token, etc.). `DOCKER_PASSWORD` makes the role obvious from the secret name alone.

## Pre-merge requirement (handled by repo owner)
- `DOCKER_USER` and `DOCKER_PASSWORD` secrets must be set on this repo before merge.
- The legacy `ACCESS_TOKEN` can be deleted after merge, once nothing references it.

## Test plan
- [ ] Trigger the next release and confirm the docker login step succeeds and the image pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
